### PR TITLE
fix compile warning that is tripping on bad logic

### DIFF
--- a/sdk/sgDecodeOperating.c
+++ b/sdk/sgDecodeOperating.c
@@ -72,7 +72,7 @@ bool sgDecodeOperating(uint8_t *buffer, operating_struct *stl)
    stl->altitude       = toInt16(sgStl.altitude) & 0x3fff; // Bit 13-0 of Altitude field
 
    // Altitude Rate
-   stl->climbValid     = (toInt16(sgStl.altitudeRate) == 0x8000) ? 0 : 1; // If alt rate = 0x8000, then alt rate is not available
+   stl->climbValid     = ((uint16_t)toInt16(sgStl.altitudeRate) == 0x8000) ? 0 : 1; // If alt rate = 0x8000, then alt rate is not available
    stl->climbRate      = toInt16(sgStl.altitudeRate) & 0xffff; // Bit 15-0 of Altitude Rate field
 
    // Heading


### PR DESCRIPTION
GCC is complaining about this line:
```
sgDecodeOperating.c:75:55: warning: comparison is always false due to limited range of data type [-Wtype-limits]
stl->climbValid     = (toInt16(sgStl.altitudeRate) == 0x8000) ? 0 : 1; // If alt rate = 0x8000, then alt rate is not available
```   

We could just call toUint16() which would probably work in this case because you're doing an unsigned ORs behind the scenes and recasting but depending on compiler versions etc etc I didn't want it to risk re-interpret the number incorrectly so this is a bit more full-proof-ish.

