### PR TITLE
sgDecodeFlightId: copy the fixed-width flight id without strcpy

### DIFF
--- a/sdk/sgDecodeFlightId.c
+++ b/sdk/sgDecodeFlightId.c
@@ -34,8 +34,11 @@ bool sgDecodeFlightId(uint8_t *buffer, sg_flightid_t *id)
    flightid_t sgId;
    memcpy(&sgId, buffer, sizeof(flightid_t));
 
-   strcpy(id->flightId, sgId.flightId);
-   memset(&id->flightId[SG_ID_LEN], '\0', 1);  // Ensure flight id is null-terminated
+   // flightId is a fixed-width field padded with spaces, not a C string. strcpy() reads
+   // until it finds a zero byte, so it runs past the field into rsvd, checksum and off the
+   // end of sgId, overflowing the smaller destination on the way.
+   memcpy(id->flightId, sgId.flightId, SG_ID_LEN);
+   id->flightId[SG_ID_LEN] = '\0';  // Ensure flight id is null-terminated
 
    return true;
 }


### PR DESCRIPTION
`flightId` is a fixed-width field padded with spaces, not a NUL-terminated C string, but `sgDecodeFlightId()` passes it to `strcpy()`.

`strcpy()` copies until it finds a zero byte. A message whose eight flight-id characters are all non-NUL makes it run past the field into `rsvd` and `checksum`, off the end of the 19-byte `flightid_t` local, and into whatever follows on the stack. The destination, `sg_flightid_t.flightId`, is nine bytes, so it overflows on the way.

This copies exactly `SG_ID_LEN` bytes and terminates. The trailing `memset` was already writing the terminator in the right place — it just ran after the overflow had happened.

Found via the copy of this SDK vendored in PX4, where the decoder is reachable from the transponder serial link and this reproduces under AddressSanitizer as a `stack-buffer-overflow` `READ of size 14`. The corresponding PX4 fix is https://github.com/PX4/PX4-Autopilot/pull/28579.

For reference, `sgDecodeInstall()` had the same pattern on `registration` and was fixed here in #3 (2023); this is the remaining instance.