### PR TITLE
sgDecodeSVR: reject frames shorter than their advertised field set

### DIFF
--- a/sdk/sgDecodeSVR.c
+++ b/sdk/sgDecodeSVR.c
@@ -62,6 +62,97 @@ bool sgDecodeSVR(uint8_t *buffer, sg_svr_t *svr)
    svr->addrType = buffer[PBASE + 8] &0xFF;
 
 
+   // Each optional field below is present only when its flag is set, and each advances the
+   // running offset. Nothing verifies that the frame actually carried them, so a truncated
+   // message decodes whatever follows it in the caller's buffer. Work out how much payload
+   // the advertised field set requires and reject the frame if it is shorter.
+   uint16_t needed = 9;
+
+   if (fields[0] & SV_PARAM_TOA_EPOS)
+   {
+      needed += 2;
+   }
+
+   if (fields[0] & SV_PARAM_TOA_POS)
+   {
+      needed += 2;
+   }
+
+   if (fields[0] & SV_PARAM_TOA_VEL)
+   {
+      needed += 2;
+   }
+
+   if (fields[0] & SV_PARAM_LATLON)
+   {
+      needed += 6;
+   }
+
+   if (svr->type == svrAirborne)
+   {
+      if (fields[1] & SV_PARAM_GEOALT)
+      {
+         needed += 3;
+      }
+
+      if (fields[1] & SV_PARAM_VEL)
+      {
+         needed += 4;
+      }
+
+      if (fields[1] & SV_PARAM_BAROALT)
+      {
+         needed += 3;
+      }
+
+      if (fields[1] & SV_PARAM_VRATE)
+      {
+         needed += 2;
+      }
+   }
+   else
+   {
+      if (fields[1] & SV_PARAM_SURF_GS)
+      {
+         needed += 1;
+      }
+
+      if (fields[1] & SV_PARAM_SURF_HEAD)
+      {
+         needed += 1;
+      }
+   }
+
+   if (fields[1] & SV_PARAM_NIC)
+   {
+      needed += 1;
+   }
+
+   if (fields[1] & SV_PARAM_ESTLAT)
+   {
+      needed += 3;
+   }
+
+   if (fields[2] & SV_PARAM_ESTLON)
+   {
+      needed += 3;
+   }
+
+   if (fields[2] & SV_PARAM_SURV)
+   {
+      needed += 1;
+   }
+
+   if (fields[2] & SV_PARAM_REPORT)
+   {
+      needed += 1;
+   }
+
+   if (buffer[3] < needed)  // buffer[3] is the advertised payload length
+   {
+      return false;
+   }
+
    uint8_t ofs = 9;
 
    if (fields[0] & SV_PARAM_TOA_EPOS)


### PR DESCRIPTION
The optional fields in `sgDecodeSVR()` are present only when their flag bit is set, and each one advances a running offset. Nothing verifies that the frame actually carried them, so a truncated message with several field bits set keeps reading forward past the end of the received data.

What that costs depends on how the caller sized its buffer:

- a caller that allocates per-frame reads out of bounds;
- a caller that reuses a fixed maximum-size buffer stays in bounds, but decodes leftover bytes from the previous message and reports a target with a fabricated position, altitude and velocity.

This sums the payload the advertised field set requires and rejects the frame when the payload length in the header is shorter. The frame already carries its own length at `buffer[3]`, so the existing signature is unchanged and callers do not need to adapt.

The corresponding PX4 fix is https://github.com/PX4/PX4-Autopilot/pull/28580. PX4 hits the second case, since it always passes a fixed-size packet structure.